### PR TITLE
Update to 0.46.2. Fixes JB#63861

### DIFF
--- a/rpm/0001-fix-allow-64-bit-time_t-on-32-bit-systems-in-test_is.patch
+++ b/rpm/0001-fix-allow-64-bit-time_t-on-32-bit-systems-in-test_is.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haixiao Yan <haixiao.yan.cn@windriver.com>
+Date: Wed, 22 Oct 2025 15:23:56 +0800
+Subject: [PATCH] fix: allow 64-bit time_t on 32-bit systems in test_is32bit
+
+Some modern 32-bit Linux systems (e.g. with glibc >= 2.34 or musl time64 ABI)
+use 64-bit time_t by default when _TIME_BITS=64 is enabled. The original test
+assumed time_t was always 32-bit on 32-bit architectures, which is no longer
+true.
+
+Relax the check to accept both 32-bit and 64-bit time_t values:
+
+    self.assertIn(bit32, (32, 64))
+
+This makes the test compatible with both legacy and time64 ABIs.
+
+Signed-off-by: Haixiao Yan <haixiao.yan.cn@windriver.com>
+---
+ tests/test_util.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_util.py b/tests/test_util.py
+index e925d03..233fb7a 100644
+--- a/tests/test_util.py
++++ b/tests/test_util.py
+@@ -26,7 +26,7 @@ class UtilTestCase(unittest.TestCase):
+                 not in ["true", "1", "yes"]
+             )
+         ):
+-            self.assertEqual(bit32, 32)
++            self.assertIn(bit32, (32, 64))
+         else:
+             self.assertNotEqual(bit32, 32)
+         self.assertIsInstance(bit32, int)

--- a/rpm/0002-fix-correct-struct-packing-on-32-bit-with-_TIME_BITS.patch
+++ b/rpm/0002-fix-correct-struct-packing-on-32-bit-with-_TIME_BITS.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haixiao Yan <haixiao.yan.cn@windriver.com>
+Date: Wed, 22 Oct 2025 15:23:57 +0800
+Subject: [PATCH] fix: correct struct packing on 32-bit with _TIME_BITS=64
+
+On 32-bit platforms with glibc time64 ABI, time_t is 64-bit wide while
+`long` remains 32-bit. This causes struct timeval to use two 64-bit fields
+(tv_sec, tv_usec). The previous code incorrectly packed timeout as "ll",
+leading to EINVAL in setsockopt(SO_RCVTIMEO).
+
+Use "qq" instead when m2.time_t_bits() == 64 to match the actual ABI.
+
+Fixes: https://todo.sr.ht/~mcepl/m2crypto/374
+Signed-off-by: Haixiao Yan <haixiao.yan.cn@windriver.com>
+---
+ src/M2Crypto/SSL/timeout.py | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/src/M2Crypto/SSL/timeout.py b/src/M2Crypto/SSL/timeout.py
+index b45f38b..5ba5228 100644
+--- a/src/M2Crypto/SSL/timeout.py
++++ b/src/M2Crypto/SSL/timeout.py
+@@ -33,10 +33,14 @@ class timeout(object):
+             millisec = int(self.sec * 1000 + round(float(self.microsec) / 1000))
+             binstr = struct.pack("l", millisec)
+         else:
+-            if m2.time_t_bits() == 32:
++            bits = m2.time_t_bits()
++            if bits == 32:
+                 binstr = struct.pack("ii", self.sec, self.microsec)
++            elif bits == 64:
++                # handle both 64-bit and 32-bit+TIME_BITS=64
++                binstr = struct.pack("qq", self.sec, self.microsec)
+             else:
+-                binstr = struct.pack("ll", self.sec, self.microsec)
++                raise ValueError(f"Unsupported time_t_bits: {bits}")
+         return binstr
+ 
+ 
+@@ -48,7 +52,13 @@ def struct_to_timeout(binstr: bytes) -> timeout:
+         sec = int(millisec / 1000)
+         microsec = (millisec % 1000) * 1000
+     else:
+-        (sec, microsec) = struct.unpack("ll", binstr)
++        bits = m2.time_t_bits()
++        if bits == 32:
++            (sec, microsec) = struct.unpack("ii", binstr)
++        elif bits == 64:
++            (sec, microsec) = struct.unpack("qq", binstr)
++        else:
++            raise ValueError(f"Unsupported time_t_bits: {bits}")
+     return timeout(sec, microsec)
+ 
+ 
+@@ -56,4 +66,10 @@ def struct_size() -> int:
+     if sys.platform == "win32":
+         return struct.calcsize("l")
+     else:
+-        return struct.calcsize("ll")
++        bits = m2.time_t_bits()
++        if bits == 32:
++            return struct.calcsize("ii")
++        elif bits == 64:
++            return struct.calcsize("qq")
++        else:
++            raise ValueError(f"Unsupported time_t_bits: {bits}")

--- a/rpm/python-M2Crypto.spec
+++ b/rpm/python-M2Crypto.spec
@@ -1,17 +1,20 @@
-Summary: Support for using OpenSSL in python scripts
-Name: python-M2Crypto
-Version: 0.41.0
-Release: 1
-Source: %{name}-%{version}.tar.gz
+Summary:       Support for using OpenSSL in python scripts
+Name:          python-M2Crypto
+Version:       0.46.2
+Release:       1
+Source:        %{name}-%{version}.tar.gz
+License:       BSD-2-Clause
+URL:           https://github.com/sailfishos/python-M2Crypto.git
 
-License: MIT
-URL: https://gitlab.com/m2crypto/m2crypto/
 BuildRequires: pkgconfig(python3)
 BuildRequires: pkgconfig(openssl)
 BuildRequires: python3-setuptools
 BuildRequires: pkgconfig
 BuildRequires: swig
 BuildRequires: fdupes
+Patch1:        0001-fix-allow-64-bit-time_t-on-32-bit-systems-in-test_is.patch
+Patch2:        0002-fix-correct-struct-packing-on-32-bit-with-_TIME_BITS.patch
+
 %description
 This package allows you to call OpenSSL functions from python scripts.
 
@@ -19,7 +22,6 @@ This package allows you to call OpenSSL functions from python scripts.
 %autosetup -p1 -n %{name}-%{version}/m2crypto
 
 %build
-export CFLAGS="%{optflags}"
 %py3_build
 
 %install
@@ -28,7 +30,6 @@ export CFLAGS="%{optflags}"
 %fdupes %{buildroot}
 
 %files
-%defattr(-,root,root,-)
-%license LICENCE
+%license LICENSES/BSD-2-Clause.txt
 %{python3_sitearch}/M2Crypto
 %{python3_sitearch}/M2Crypto-*.egg-info/


### PR DESCRIPTION
Needed for OpenSSL update.

Added two patched from upstream for handling 64-bit time_t on 32-bit systems.

Spec cleanup.